### PR TITLE
大佬，发现您的项目引入了io.netty:netty-codec-http@4.1.65.Final组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -32,7 +31,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <spring-boot.version>2.4.5</spring-boot.version>
         <dubbo-spring-boot-starter.version>2.7.5</dubbo-spring-boot-starter.version>
-        <netty.version>4.1.65.Final</netty.version>
+        <netty.version>4.1.71.Final</netty.version>
         <dubbo.version>2.7.5</dubbo.version>
         <nacos.version>2.0.2</nacos.version>
         <nacos-config-spring-boot-starter.version>0.2.8</nacos-config-spring-boot-starter.version>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Netty 安全漏洞
缺陷组件：io.netty:netty-codec-http@4.1.65.Final
漏洞编号：CVE-2021-43797
漏洞描述：Netty是Netty社区的一款非阻塞I/O客户端-服务器框架，它主要用于开发Java网络应用程序，如协议服务器和客户端等。
Netty 存在安全漏洞，该漏洞源于Netty是一个异步事件驱动的网络应用框架，用于快速开发可维护的高性能协议服务器和客户端。版本4.1.7.1之前的Netty。当控件字符出现在头名称的开头和结尾时，Final将跳过它们。相反，它应该很快失败，因为这是规范不允许的，可能会导致HTTP请求走私。如果没有进行验证，netty可能会在将这些头名称转发给另一个用作代理的远程系统之前对其进行“消毒”。这个远程系统无法再看到无效的使用，因此无法看到
影响范围：(∞, 4.1.71.Final)
最小修复版本：4.1.71.Final
缺陷组件引入路径：com.zyblue:fastim-gate-http@0.0.1-SNAPSHOT->io.netty:netty-codec-http@4.1.65.Final
```
另外我运行这个项目时，IDE的安全插件提示还有26个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p84989